### PR TITLE
avoid sending parent process parameters to forked process

### DIFF
--- a/lib/scrypt-async.js
+++ b/lib/scrypt-async.js
@@ -8,7 +8,7 @@ var max_workers = cpu_count - 1;
 var pool = pool = new gp.Pool({
 	name: 'scrypt-worker'
 	,create: function(callback) {
-		var worker = fork(__dirname + '/scrypt-async-worker.js');
+		var worker = fork(__dirname + '/scrypt-async-worker.js',{execArgv:[]});
 		worker.controlledExit = false;
 		worker.on('exit',function(){
 			if (!worker.controlledExit) {


### PR DESCRIPTION
When running the parent process with "debug" parameter, the child process tries to open the same port, an error is displayed in the console.
This fix, sends no parameters to the forked process.
